### PR TITLE
fix: React 18 and StrictMode support

### DIFF
--- a/src/hooks/useStatus.ts
+++ b/src/hooks/useStatus.ts
@@ -85,10 +85,10 @@ export default function useStatus(
       canEnd = onLeaveEnd?.(element, event);
     }
 
-    // Only update status when `canEnd` and not destroyed
+    // Only update status when `canEnd`
     if (canEnd !== false) {
-      setStatus(STATUS_NONE, true);
-      setStyle(null, true);
+      setStatus(STATUS_NONE);
+      setStyle(null);
     }
   }
 
@@ -169,7 +169,13 @@ export default function useStatus(
     setAsyncVisible(visible);
 
     const isMounted = mountedRef.current;
-    mountedRef.current = true;
+
+    // In React 18 and StrictMode, React intentionally double-invokes effects (mount -> unmount -> mount) for newly mounted components.
+    // ref: https://github.com/reactwg/react-18/discussions/19
+    // This is a workaround to prevent 'nextStatus' from being judged as 'Leave' in the initial render.
+    setTimeout(() => {
+      mountedRef.current = true;
+    }, 0);
 
     if (!supportMotion) {
       return;

--- a/src/hooks/useStepQueue.ts
+++ b/src/hooks/useStepQueue.ts
@@ -38,7 +38,7 @@ export default (
   const [nextFrame, cancelNextFrame] = useNextFrame();
 
   function startQueue() {
-    setStep(STEP_PREPARE, true);
+    setStep(STEP_PREPARE);
   }
 
   useIsomorphicLayoutEffect(() => {
@@ -50,7 +50,7 @@ export default (
 
       if (result === SkipStep) {
         // Skip when no needed
-        setStep(nextStep, true);
+        setStep(nextStep);
       } else {
         // Do as frame for step update
         nextFrame(info => {
@@ -58,7 +58,7 @@ export default (
             // Skip since current queue is ood
             if (info.isCanceled()) return;
 
-            setStep(nextStep, true);
+            setStep(nextStep);
           }
 
           if (result === true) {

--- a/tests/CSSMotion.spec.tsx
+++ b/tests/CSSMotion.spec.tsx
@@ -108,6 +108,10 @@ describe('CSSMotion', () => {
         const nextVisible = visible[1];
         const wrapper = mount(<Demo />);
 
+        act(() => {
+          jest.runOnlyPendingTimers();
+        });
+
         function doStartTest() {
           wrapper.update();
           const boxNode = wrapper.find('.motion-box');
@@ -340,6 +344,9 @@ describe('CSSMotion', () => {
 
       it(name, () => {
         const wrapper = mount(<Demo />);
+        act(() => {
+          jest.runOnlyPendingTimers();
+        });
         wrapper.update();
         const nextVisible = visible[1];
 
@@ -377,6 +384,10 @@ describe('CSSMotion', () => {
         )}
       </CSSMotion>,
     );
+
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
 
     wrapper.setProps({
       motionName: 'animation',


### PR DESCRIPTION
This PR will fix https://github.com/ant-design/ant-design/issues/34788.

In React18 StrictMode, React intentionally calls the effect twice (mount -> unmount -> mount) for a newly mounted component.

This presented the following two issues

- The `nextStatus` becomes 'Leave' on the second mount in the initial rendering.
- Because the unmount process of useEffect is executed in the initial rendering, the state cannot always be updated if `ignoreDestroy` is set in useState of rc-util.

This MR solves these two issues.

I would appreciate your feedback on the use of setTimeout as a workaround and whether removing the `ignoreDestroy` setting will cause problems.