### PR TITLE
fix: reset mounted flag when component destroyed

### DIFF
--- a/src/hooks/useStatus.ts
+++ b/src/hooks/useStatus.ts
@@ -219,6 +219,7 @@ export default function useStatus(
 
   useEffect(
     () => () => {
+      mountedRef.current = false;
       clearTimeout(deadlineRef.current);
     },
     [],


### PR DESCRIPTION
fix: https://github.com/ant-design/ant-design/issues/34788
fix: https://github.com/ant-design/ant-design/issues/34850

In the second rendering of StrictMode, `nextState` will be set to `STATUS_LEAVE` because `isMounted` has turned into `true`:
https://github.com/react-component/motion/blob/757821e836786443c7191d08be4715b09d307a59/src/hooks/useStatus.ts#L190-L196

which leads to unexpected visible loading icon:
https://github.com/react-component/motion/blob/757821e836786443c7191d08be4715b09d307a59/src/CSSMotion.tsx#L209-L221
