### PR TITLE
fix: kip useless active

### DIFF
--- a/src/hooks/useStatus.ts
+++ b/src/hooks/useStatus.ts
@@ -76,17 +76,19 @@ export default function useStatus(
       return;
     }
 
+    const currentActive = activeRef.current;
+
     let canEnd: boolean | void;
-    if (status === STATUS_APPEAR && activeRef.current) {
+    if (status === STATUS_APPEAR && currentActive) {
       canEnd = onAppearEnd?.(element, event);
-    } else if (status === STATUS_ENTER && activeRef.current) {
+    } else if (status === STATUS_ENTER && currentActive) {
       canEnd = onEnterEnd?.(element, event);
-    } else if (status === STATUS_LEAVE && activeRef.current) {
+    } else if (status === STATUS_LEAVE && currentActive) {
       canEnd = onLeaveEnd?.(element, event);
     }
 
     // Only update status when `canEnd` and not destroyed
-    if (canEnd !== false) {
+    if (status !== STATUS_NONE && currentActive && canEnd !== false) {
       setStatus(STATUS_NONE, true);
       setStyle(null, true);
     }


### PR DESCRIPTION
游览器在切换 Tab 时动画会暂停，在切换回来时有小概率遇到游览器回复动画触发 motionEnd 但是 CSSMotion 已经进入下一个动画状态被强制重置的情况。加一个判断，只有在流程中的 status 才可以被中断。

https://github.com/ant-design/ant-design/pull/34319#issuecomment-1084068312