### PR TITLE
fix: remove delete statement on render for react 18

### DIFF
--- a/src/CSSMotionList.tsx
+++ b/src/CSSMotionList.tsx
@@ -1,17 +1,19 @@
 /* eslint react/prop-types: 0 */
+import omit from 'rc-util/lib/omit';
 import * as React from 'react';
-import OriginCSSMotion from './CSSMotion';
 import type { CSSMotionProps } from './CSSMotion';
-import { supportTransition } from './util/motion';
+import OriginCSSMotion from './CSSMotion';
+import type { KeyObject } from './util/diff';
 import {
+  diffKeys,
+  parseKeys,
   STATUS_ADD,
   STATUS_KEEP,
   STATUS_REMOVE,
   STATUS_REMOVED,
-  diffKeys,
-  parseKeys,
 } from './util/diff';
-import type { KeyObject } from './util/diff';
+import { supportTransition } from './util/motion';
+import pick from './util/pick';
 
 const MOTION_PROP_NAMES = [
   'eventProps',
@@ -127,16 +129,11 @@ export function genCSSMotionList(
       } = this.props;
 
       const Component = component || React.Fragment;
-
-      const motionProps: CSSMotionProps = {};
-      MOTION_PROP_NAMES.forEach(prop => {
-        motionProps[prop] = restProps[prop];
-        delete restProps[prop];
-      });
-      delete restProps.keys;
+      const motionProps = pick(restProps, MOTION_PROP_NAMES as any);
+      const componentProps = omit(restProps, MOTION_PROP_NAMES as any);
 
       return (
-        <Component {...restProps}>
+        <Component {...componentProps}>
           {keyEntities.map(({ status, ...eventProps }) => {
             const visible = status === STATUS_ADD || status === STATUS_KEEP;
             return (

--- a/src/util/pick.ts
+++ b/src/util/pick.ts
@@ -1,0 +1,14 @@
+export default function pick<T extends object, K extends keyof T>(
+  obj: T,
+  fields: K[],
+): Pick<T, K> {
+  const clone = {} as Pick<T, K>;
+
+  if (Array.isArray(fields)) {
+    fields.forEach(key => {
+      clone[key] = obj[key];
+    });
+  }
+
+  return clone;
+}


### PR DESCRIPTION
## 解决的问题：
在React18中，在render里面操作delete容易导致意外的情况
## 问题描述：
在给antd迁移upload的测试库到testing-lib的时候
发现下面的用例修改完语法之后在React18中一直无法通过测试
https://github.com/ant-design/ant-design/blob/master/components/upload/__tests__/uploadlist.test.js#L112-L152
uid为0的记录在删除时一直处在`animate-leave-active`的状态
<img width="1233" alt="image" src="https://user-images.githubusercontent.com/15713772/173515547-eb51eb2a-4cb9-4317-9d6c-de4c5c7be202.png">
调试过程中发现为CSSMotionList在调用CSSMotion组件时传入的onVisibleChange偶尔会变成undifined导致的问题
https://github.com/react-component/motion/blob/59dc90cd3645f9dfa95d4e7df68a5f06f3884e85/src/CSSMotionList.tsx#L143-L159
在测试用例中打印下图中的props.onVisibleChange会发现在某一时间点之后成了undefined，导致节点删不掉
https://github.com/react-component/motion/blob/59dc90cd3645f9dfa95d4e7df68a5f06f3884e85/src/CSSMotion.tsx#L154-L159
## 解决方法：
将CSSMotionList.tsx里render中的delete操作替换为不修改原对象的取值操作，测试即可通过
