### PR TITLE
fix: element remove leak

### DIFF
--- a/src/CSSMotionList.tsx
+++ b/src/CSSMotionList.tsx
@@ -92,19 +92,10 @@ export function genCSSMotionList(
       const mixedKeyEntities = diffKeys(keyEntities, parsedKeyObjects);
 
       return {
-        keyEntities: mixedKeyEntities.filter(entity => {
-          const prevEntity = keyEntities.find(({ key }) => entity.key === key);
-
+        keyEntities: mixedKeyEntities.filter(
           // Remove if already mark as removed
-          if (
-            prevEntity &&
-            prevEntity.status === STATUS_REMOVED &&
-            entity.status === STATUS_REMOVE
-          ) {
-            return false;
-          }
-          return true;
-        }),
+          entity => entity.status !== STATUS_REMOVE, 
+        ),
       };
     }
 

--- a/src/CSSMotionList.tsx
+++ b/src/CSSMotionList.tsx
@@ -1,6 +1,5 @@
 /* eslint react/prop-types: 0 */
 import * as React from 'react';
-
 import type { CSSMotionProps } from './CSSMotion';
 import OriginCSSMotion from './CSSMotion';
 import type { KeyObject } from './util/diff';


### PR DESCRIPTION
## Description
清理掉remove状态的元素 否则元素并不会被释放造成了内存泄漏的情况

## Visuals

修改前的dom节点：
<img width="1630" alt="image" src="https://github.com/user-attachments/assets/7df185fb-d656-4fb8-a602-e28e68be21f8">


修改后的dom节点：
修改后元素始终保持一个数值内 之前并没有清理掉remove状态的元素
<img width="1646" alt="image" src="https://github.com/user-attachments/assets/329aa558-e71d-4d3b-8fdc-6659b0f5b047">



## Checklist

- [x] My code follows the style guidelines and recommended practices of this project
- [x] I have performed a self-review of my own code and fixed the problems I found
- [x] I have tested my change that my fix is effective or that my feature works, and that it does not break existing functionality.

## Any TODOs?

A summary of any remaining work required to complete the requirements of the task.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **新功能**
	- 优化了过滤逻辑，提高了性能和可理解性，简化了处理状态为移除的实体的方式。
	- 改进了状态管理，确保在移除所有键时正确触发回调。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->