### PR TITLE
fix: suspense repeat trigger

### DIFF
--- a/src/hooks/useStatus.ts
+++ b/src/hooks/useStatus.ts
@@ -191,8 +191,17 @@ export default function useStatus(
   activeRef.current = active;
 
   // ============================ Status ============================
+  const visibleRef = useRef<boolean | null>(null);
+
   // Update with new status
   useIsomorphicLayoutEffect(() => {
+    // When use Suspense, the `visible` will repeat trigger,
+    // But not real change of the `visible`, we need to skip it.
+    // https://github.com/ant-design/ant-design/issues/44379
+    if (mountedRef.current && visibleRef.current === visible) {
+      return;
+    }
+
     setAsyncVisible(visible);
 
     const isMounted = mountedRef.current;
@@ -232,6 +241,8 @@ export default function useStatus(
       // Set back in case no motion but prev status has prepare step
       setStatus(STATUS_NONE);
     }
+
+    visibleRef.current = visible;
   }, [visible]);
 
   // ============================ Effect ============================


### PR DESCRIPTION
Suspense 下，`useEffect` 会重复触发。导致当 `visible=false` 被重复触发时，认为是从可见变成不可见。导致触发移除动画。额外包一个 ref 来记录真正的状态。

fix https://github.com/ant-design/ant-design/issues/44379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新特性**
	- 引入了新的引用 `visibleRef`，用于跟踪可见性状态，优化了组件在重新渲染时的更新效率。
- **修复**
	- 改进了 `useIsomorphicLayoutEffect` 钩子的逻辑，确保在可见性状态未更改时跳过不必要的更新。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->