### PR TITLE
feat: remove findDOMNode

### DIFF
--- a/src/CSSMotion.tsx
+++ b/src/CSSMotion.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/default-props-match-prop-types, react/no-multi-comp, react/prop-types */
 import classNames from 'classnames';
-import findDOMNode from 'rc-util/lib/Dom/findDOMNode';
+import { getDOM } from 'rc-util/lib/Dom/findDOMNode';
 import { fillRef, getNodeRef, supportRef } from 'rc-util/lib/ref';
 import * as React from 'react';
 import { useRef } from 'react';
@@ -142,13 +142,9 @@ export function genCSSMotion(config: CSSMotionConfig) {
 
     function getDomElement() {
       try {
-        // Here we're avoiding call for findDOMNode since it's deprecated
-        // in strict mode. We're calling it only when node ref is not
-        // an instance of DOM HTMLElement. Otherwise use
-        // findDOMNode as a final resort
         return nodeRef.current instanceof HTMLElement
           ? nodeRef.current
-          : findDOMNode<HTMLElement>(wrapperNodeRef.current);
+          : (getDOM(nodeRef.current) as HTMLElement);
       } catch (e) {
         // Only happen when `motionDeadline` trigger but element removed.
         return null;

--- a/tests/CSSMotion.spec.tsx
+++ b/tests/CSSMotion.spec.tsx
@@ -5,7 +5,6 @@
 import { act, fireEvent, render } from '@testing-library/react';
 import classNames from 'classnames';
 import React from 'react';
-import ReactDOM from 'react-dom';
 import type { CSSMotionProps } from '../src';
 import { Provider } from '../src';
 import RefCSSMotion, { genCSSMotion } from '../src/CSSMotion';
@@ -828,78 +827,6 @@ describe('CSSMotion', () => {
 
     expect(container.querySelector('.motion-box')).toBeTruthy();
     expect(container.querySelector('.motion-box')).toHaveClass('removed');
-  });
-
-  describe('strict mode', () => {
-    beforeEach(() => {
-      jest.spyOn(ReactDOM, 'findDOMNode');
-    });
-
-    afterEach(() => {
-      jest.resetAllMocks();
-    });
-
-    it('calls findDOMNode when no refs are passed', () => {
-      const Div = () => <div />;
-      render(
-        <CSSMotion motionName="transition" visible>
-          {() => <Div />}
-        </CSSMotion>,
-      );
-
-      act(() => {
-        jest.runAllTimers();
-      });
-
-      expect(ReactDOM.findDOMNode).toHaveBeenCalled();
-    });
-
-    it('does not call findDOMNode when ref is passed internally', () => {
-      render(
-        <CSSMotion motionName="transition" visible>
-          {(props, ref) => <div ref={ref} />}
-        </CSSMotion>,
-      );
-
-      act(() => {
-        jest.runAllTimers();
-      });
-
-      expect(ReactDOM.findDOMNode).not.toHaveBeenCalled();
-    });
-
-    it('calls findDOMNode when refs are forwarded but not assigned', () => {
-      const domRef = React.createRef();
-      const Div = () => <div />;
-
-      render(
-        <CSSMotion motionName="transition" visible ref={domRef}>
-          {() => <Div />}
-        </CSSMotion>,
-      );
-
-      act(() => {
-        jest.runAllTimers();
-      });
-
-      expect(ReactDOM.findDOMNode).toHaveBeenCalled();
-    });
-
-    it('does not call findDOMNode when refs are forwarded and assigned', () => {
-      const domRef = React.createRef();
-
-      render(
-        <CSSMotion motionName="transition" visible ref={domRef}>
-          {(props, ref) => <div ref={ref} />}
-        </CSSMotion>,
-      );
-
-      act(() => {
-        jest.runAllTimers();
-      });
-
-      expect(ReactDOM.findDOMNode).not.toHaveBeenCalled();
-    });
   });
 
   describe('onVisibleChanged', () => {


### PR DESCRIPTION
issue: https://github.com/ant-design/ant-design/issues/52115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **重构**
	- 移除了 `CSSMotion` 组件中已弃用的 `findDOMNode` 方法
	- 简化了处理 DOM 引用的逻辑

- **测试**
	- 删除了与严格模式相关的测试用例
	- 保留了组件其他关键行为的测试

<!-- end of auto-generated comment: release notes by coderabbit.ai -->