### PR TITLE
refactor: make ref stable

### DIFF
--- a/src/CSSMotion.tsx
+++ b/src/CSSMotion.tsx
@@ -163,7 +163,7 @@ export function genCSSMotion(config: CSSMotionConfig) {
       }
 
       // ====================== Refs ======================
-      const [refObj] = React.useState<CSSMotionRef>(() => {
+      const refObj = React.useMemo<CSSMotionRef>(() => {
         const obj = {} as CSSMotionRef;
         Object.defineProperties(obj, {
           nativeElement: {
@@ -178,7 +178,7 @@ export function genCSSMotion(config: CSSMotionConfig) {
           },
         });
         return obj;
-      });
+      }, []);
 
       // We lock `deps` here since function return object
       // will repeat trigger ref from `refConfig` -> `null` -> `refConfig`

--- a/src/hooks/useStatus.ts
+++ b/src/hooks/useStatus.ts
@@ -49,7 +49,7 @@ export default function useStatus(
     onLeaveEnd,
     onVisibleChanged,
   }: CSSMotionProps,
-): [MotionStatus, StepStatus, React.CSSProperties, boolean] {
+): [() => MotionStatus, StepStatus, React.CSSProperties, boolean] {
   // Used for outer render usage to avoid `visible: false & status: none` to render nothing
   const [asyncVisible, setAsyncVisible] = useState<boolean>();
   const [getStatus, setStatus] = useSyncState<MotionStatus>(STATUS_NONE);
@@ -294,5 +294,5 @@ export default function useStatus(
     };
   }
 
-  return [currentStatus, step, mergedStyle, asyncVisible ?? visible];
+  return [getStatus, step, mergedStyle, asyncVisible ?? visible];
 }


### PR DESCRIPTION
`ref` 返回 obj 时，每次 render 都会做一次 `fill` -> `null` -> `fill` 的填充，导致和原本的渲染逻辑不一致。这里让 refObj 变成稳定态以与 rc 版本保持一致。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **重构**
  - 优化了动画组件的内部状态管理和引用处理，使得动画效果在展示时更加稳定、响应更及时，从而提升整体视觉体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->