### PR TITLE
fix: compose existing child refs in CSSMotion

### DIFF
--- a/src/CSSMotion.tsx
+++ b/src/CSSMotion.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/default-props-match-prop-types, react/no-multi-comp, react/prop-types */
 import { getDOM } from '@rc-component/util/lib/Dom/findDOMNode';
-import { getNodeRef, supportRef } from '@rc-component/util/lib/ref';
+import { composeRef, getNodeRef, supportRef } from '@rc-component/util/lib/ref';
 import { clsx } from 'clsx';
 import * as React from 'react';
 import { useRef } from 'react';
@@ -253,14 +253,12 @@ export function genCSSMotion(config: CSSMotionConfig) {
         ) {
           const originNodeRef = getNodeRef(motionChildren);
 
-          if (!originNodeRef) {
-            motionChildren = React.cloneElement(
-              motionChildren as React.ReactElement,
-              {
-                ref: nodeRef,
-              },
-            );
-          }
+          motionChildren = React.cloneElement(
+            motionChildren as React.ReactElement,
+            {
+              ref: originNodeRef ? composeRef(originNodeRef, nodeRef) : nodeRef,
+            },
+          );
         }
 
         return motionChildren;

--- a/src/CSSMotion.tsx
+++ b/src/CSSMotion.tsx
@@ -1,6 +1,10 @@
 /* eslint-disable react/default-props-match-prop-types, react/no-multi-comp, react/prop-types */
 import { getDOM } from '@rc-component/util/lib/Dom/findDOMNode';
-import { composeRef, getNodeRef, supportRef } from '@rc-component/util/lib/ref';
+import {
+  getNodeRef,
+  supportRef,
+  useComposeRef,
+} from '@rc-component/util/lib/ref';
 import { clsx } from 'clsx';
 import * as React from 'react';
 import { useRef } from 'react';
@@ -189,7 +193,7 @@ export function genCSSMotion(config: CSSMotionConfig) {
       }
 
       // We should render children when motionStyle is sync with stepStatus
-      return React.useMemo(() => {
+      const motionChildren = React.useMemo(() => {
         if (styleReady === 'NONE') {
           return null;
         }
@@ -246,23 +250,27 @@ export function genCSSMotion(config: CSSMotionConfig) {
           );
         }
 
-        // Auto inject ref if child node not have `ref` props
-        if (
-          React.isValidElement(motionChildren) &&
-          supportRef(motionChildren)
-        ) {
-          const originNodeRef = getNodeRef(motionChildren);
-
-          motionChildren = React.cloneElement(
-            motionChildren as React.ReactElement,
-            {
-              ref: originNodeRef ? composeRef(originNodeRef, nodeRef) : nodeRef,
-            },
-          );
-        }
-
         return motionChildren;
       }, [idRef.current]) as React.ReactElement;
+
+      const canHoldRef =
+        React.isValidElement(motionChildren) && supportRef(motionChildren);
+      const originNodeRef = canHoldRef ? getNodeRef(motionChildren) : null;
+      const shouldInjectRef = canHoldRef && originNodeRef !== nodeRef;
+      const mergedNodeRef = useComposeRef(
+        shouldInjectRef ? originNodeRef : null,
+        nodeRef,
+      );
+
+      // Preserve original behavior when child already uses motion's ref directly.
+      // Only compose refs when child owns another ref or misses the motion ref.
+      if (shouldInjectRef) {
+        return React.cloneElement(motionChildren, {
+          ref: mergedNodeRef,
+        });
+      }
+
+      return motionChildren;
     },
   );
 

--- a/src/CSSMotion.tsx
+++ b/src/CSSMotion.tsx
@@ -197,12 +197,12 @@ export function genCSSMotion(config: CSSMotionConfig) {
       }
 
       // We should render children when motionStyle is sync with stepStatus
-      const returnNode = React.useMemo(() => {
+      const returnNode = React.useMemo<React.ReactElement | null>(() => {
         if (styleReady === 'NONE') {
           return null;
         }
 
-        let motionChildren: React.ReactNode;
+        let motionChildren: React.ReactElement | null;
         const mergedProps = { ...eventProps, visible };
 
         if (!children) {
@@ -255,7 +255,7 @@ export function genCSSMotion(config: CSSMotionConfig) {
         }
 
         return motionChildren;
-      }, [idRef.current]) as React.ReactElement;
+      }, [idRef.current]);
 
       if (isRefNotConsumed(children) && supportNodeRef(returnNode)) {
         const originNodeRef = getNodeRef(returnNode);

--- a/src/CSSMotion.tsx
+++ b/src/CSSMotion.tsx
@@ -253,7 +253,9 @@ export function genCSSMotion(config: CSSMotionConfig) {
         return nextMotionChildren;
       }, [idRef.current]) as React.ReactElement;
 
-      if (supportNodeRef(motionChildren)) {
+      const shouldAutoInjectRef = children?.length < 2;
+
+      if (shouldAutoInjectRef && supportNodeRef(motionChildren)) {
         const originNodeRef = getNodeRef(motionChildren);
 
         if (originNodeRef !== nodeRef) {

--- a/src/CSSMotion.tsx
+++ b/src/CSSMotion.tsx
@@ -110,7 +110,7 @@ export interface CSSMotionState {
   prevProps?: CSSMotionProps;
 }
 
-export function isRefConsume(children?: CSSMotionProps['children']) {
+export function isRefNotConsumed(children?: CSSMotionProps['children']) {
   return children?.length < 2;
 }
 
@@ -257,7 +257,7 @@ export function genCSSMotion(config: CSSMotionConfig) {
         return motionChildren;
       }, [idRef.current]) as React.ReactElement;
 
-      if (isRefConsume(children) && supportNodeRef(returnNode)) {
+      if (isRefNotConsumed(children) && supportNodeRef(returnNode)) {
         const originNodeRef = getNodeRef(returnNode);
 
         if (originNodeRef !== nodeRef) {

--- a/src/CSSMotion.tsx
+++ b/src/CSSMotion.tsx
@@ -110,6 +110,10 @@ export interface CSSMotionState {
   prevProps?: CSSMotionProps;
 }
 
+export function isRefConsume(children?: CSSMotionProps['children']) {
+  return children?.length < 2;
+}
+
 /**
  * `transitionSupport` is used for none transition test case.
  * Default we use browser transition event support check.
@@ -193,33 +197,33 @@ export function genCSSMotion(config: CSSMotionConfig) {
       }
 
       // We should render children when motionStyle is sync with stepStatus
-      const motionChildren = React.useMemo(() => {
+      const returnNode = React.useMemo(() => {
         if (styleReady === 'NONE') {
           return null;
         }
 
-        let nextMotionChildren: React.ReactNode;
+        let motionChildren: React.ReactNode;
         const mergedProps = { ...eventProps, visible };
 
         if (!children) {
           // No children
-          nextMotionChildren = null;
+          motionChildren = null;
         } else if (status === STATUS_NONE) {
           // Stable children
           if (mergedVisible) {
-            nextMotionChildren = children({ ...mergedProps }, nodeRef);
+            motionChildren = children({ ...mergedProps }, nodeRef);
           } else if (!removeOnLeave && renderedRef.current && leavedClassName) {
-            nextMotionChildren = children(
+            motionChildren = children(
               { ...mergedProps, className: leavedClassName },
               nodeRef,
             );
           } else if (forceRender || (!removeOnLeave && !leavedClassName)) {
-            nextMotionChildren = children(
+            motionChildren = children(
               { ...mergedProps, style: { display: 'none' } },
               nodeRef,
             );
           } else {
-            nextMotionChildren = null;
+            motionChildren = null;
           }
         } else {
           // In motion
@@ -237,7 +241,7 @@ export function genCSSMotion(config: CSSMotionConfig) {
             `${status}-${statusSuffix}`,
           );
 
-          nextMotionChildren = children(
+          motionChildren = children(
             {
               ...mergedProps,
               className: clsx(getTransitionName(motionName, status), {
@@ -250,22 +254,20 @@ export function genCSSMotion(config: CSSMotionConfig) {
           );
         }
 
-        return nextMotionChildren;
+        return motionChildren;
       }, [idRef.current]) as React.ReactElement;
 
-      const shouldAutoInjectRef = children?.length < 2;
-
-      if (shouldAutoInjectRef && supportNodeRef(motionChildren)) {
-        const originNodeRef = getNodeRef(motionChildren);
+      if (isRefConsume(children) && supportNodeRef(returnNode)) {
+        const originNodeRef = getNodeRef(returnNode);
 
         if (originNodeRef !== nodeRef) {
-          return React.cloneElement(motionChildren, {
+          return React.cloneElement(returnNode, {
             ref: composeRef(originNodeRef, nodeRef),
           });
         }
       }
 
-      return motionChildren;
+      return returnNode;
     },
   );
 

--- a/src/CSSMotion.tsx
+++ b/src/CSSMotion.tsx
@@ -261,7 +261,7 @@ export function genCSSMotion(config: CSSMotionConfig) {
         const originNodeRef = getNodeRef(returnNode);
 
         if (originNodeRef !== nodeRef) {
-          return React.cloneElement(returnNode, {
+          return React.cloneElement(returnNode as any, {
             ref: composeRef(originNodeRef, nodeRef),
           });
         }

--- a/src/CSSMotion.tsx
+++ b/src/CSSMotion.tsx
@@ -1,9 +1,9 @@
 /* eslint-disable react/default-props-match-prop-types, react/no-multi-comp, react/prop-types */
 import { getDOM } from '@rc-component/util/lib/Dom/findDOMNode';
 import {
+  composeRef,
   getNodeRef,
-  supportRef,
-  useComposeRef,
+  supportNodeRef,
 } from '@rc-component/util/lib/ref';
 import { clsx } from 'clsx';
 import * as React from 'react';
@@ -198,28 +198,28 @@ export function genCSSMotion(config: CSSMotionConfig) {
           return null;
         }
 
-        let motionChildren: React.ReactNode;
+        let nextMotionChildren: React.ReactNode;
         const mergedProps = { ...eventProps, visible };
 
         if (!children) {
           // No children
-          motionChildren = null;
+          nextMotionChildren = null;
         } else if (status === STATUS_NONE) {
           // Stable children
           if (mergedVisible) {
-            motionChildren = children({ ...mergedProps }, nodeRef);
+            nextMotionChildren = children({ ...mergedProps }, nodeRef);
           } else if (!removeOnLeave && renderedRef.current && leavedClassName) {
-            motionChildren = children(
+            nextMotionChildren = children(
               { ...mergedProps, className: leavedClassName },
               nodeRef,
             );
           } else if (forceRender || (!removeOnLeave && !leavedClassName)) {
-            motionChildren = children(
+            nextMotionChildren = children(
               { ...mergedProps, style: { display: 'none' } },
               nodeRef,
             );
           } else {
-            motionChildren = null;
+            nextMotionChildren = null;
           }
         } else {
           // In motion
@@ -237,7 +237,7 @@ export function genCSSMotion(config: CSSMotionConfig) {
             `${status}-${statusSuffix}`,
           );
 
-          motionChildren = children(
+          nextMotionChildren = children(
             {
               ...mergedProps,
               className: clsx(getTransitionName(motionName, status), {
@@ -250,24 +250,17 @@ export function genCSSMotion(config: CSSMotionConfig) {
           );
         }
 
-        return motionChildren;
+        return nextMotionChildren;
       }, [idRef.current]) as React.ReactElement;
 
-      const canHoldRef =
-        React.isValidElement(motionChildren) && supportRef(motionChildren);
-      const originNodeRef = canHoldRef ? getNodeRef(motionChildren) : null;
-      const shouldInjectRef = canHoldRef && originNodeRef !== nodeRef;
-      const mergedNodeRef = useComposeRef(
-        shouldInjectRef ? originNodeRef : null,
-        nodeRef,
-      );
+      if (supportNodeRef(motionChildren)) {
+        const originNodeRef = getNodeRef(motionChildren);
 
-      // Preserve original behavior when child already uses motion's ref directly.
-      // Only compose refs when child owns another ref or misses the motion ref.
-      if (shouldInjectRef) {
-        return React.cloneElement(motionChildren, {
-          ref: mergedNodeRef,
-        });
+        if (originNodeRef !== nodeRef) {
+          return React.cloneElement(motionChildren, {
+            ref: composeRef(originNodeRef, nodeRef),
+          });
+        }
       }
 
       return motionChildren;

--- a/src/CSSMotionList.tsx
+++ b/src/CSSMotionList.tsx
@@ -174,7 +174,9 @@ export function genCSSMotionList(
                   }
                 }}
               >
-                {(props, ref) => children({ ...props, index }, ref)}
+                {children.length < 2
+                  ? props => children({ ...props, index }, undefined as any)
+                  : (props, ref) => children({ ...props, index }, ref)}
               </CSSMotion>
             );
           })}

--- a/src/CSSMotionList.tsx
+++ b/src/CSSMotionList.tsx
@@ -1,7 +1,7 @@
 /* eslint react/prop-types: 0 */
 import * as React from 'react';
 import type { CSSMotionProps } from './CSSMotion';
-import OriginCSSMotion from './CSSMotion';
+import OriginCSSMotion, { isRefConsume } from './CSSMotion';
 import type { KeyObject } from './util/diff';
 import {
   diffKeys,
@@ -58,6 +58,10 @@ export interface CSSMotionListProps
     ref: React.Ref<any>,
   ) => React.ReactElement;
 }
+
+type ChildrenWithoutRef = (
+  props: Parameters<CSSMotionListProps['children']>[0],
+) => ReturnType<CSSMotionListProps['children']>;
 
 export interface CSSMotionListState {
   keyEntities: KeyObject[];
@@ -174,8 +178,12 @@ export function genCSSMotionList(
                   }
                 }}
               >
-                {children.length < 2
-                  ? props => children({ ...props, index }, undefined as any)
+                {isRefConsume(children)
+                  ? props =>
+                      (children as ChildrenWithoutRef)({
+                        ...props,
+                        index,
+                      })
                   : (props, ref) => children({ ...props, index }, ref)}
               </CSSMotion>
             );

--- a/src/CSSMotionList.tsx
+++ b/src/CSSMotionList.tsx
@@ -1,7 +1,7 @@
 /* eslint react/prop-types: 0 */
 import * as React from 'react';
 import type { CSSMotionProps } from './CSSMotion';
-import OriginCSSMotion, { isRefConsume } from './CSSMotion';
+import OriginCSSMotion, { isRefNotConsumed } from './CSSMotion';
 import type { KeyObject } from './util/diff';
 import {
   diffKeys,
@@ -178,7 +178,7 @@ export function genCSSMotionList(
                   }
                 }}
               >
-                {isRefConsume(children)
+                {isRefNotConsumed(children)
                   ? props =>
                       (children as ChildrenWithoutRef)({
                         ...props,

--- a/tests/CSSMotion.spec.tsx
+++ b/tests/CSSMotion.spec.tsx
@@ -942,6 +942,51 @@ describe('CSSMotion', () => {
 
       expect(ReactDOM.findDOMNode).not.toHaveBeenCalled();
     });
+
+    it('supports existing child refs for motion end', () => {
+      const motionRef = React.createRef<CSSMotionRef>();
+      const childRef = React.createRef<HTMLDivElement>();
+
+      const Demo = ({ visible }: { visible: boolean }) => (
+        <CSSMotion
+          motionName="transition"
+          motionAppear={false}
+          visible={visible}
+          ref={motionRef}
+        >
+          {({ style, className }) => (
+            <div
+              ref={childRef}
+              style={style}
+              className={clsx('motion-box', className)}
+            />
+          )}
+        </CSSMotion>
+      );
+
+      const { container, rerender } = render(<Demo visible />);
+
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      expect(motionRef.current.nativeElement).toBe(childRef.current);
+
+      rerender(<Demo visible={false} />);
+
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      fireEvent.transitionEnd(childRef.current!);
+
+      act(() => {
+        jest.runAllTimers();
+      });
+
+      expect(container.querySelector('.motion-box')).toBeFalsy();
+      expect(ReactDOM.findDOMNode).not.toHaveBeenCalled();
+    });
   });
 
   describe('onVisibleChanged', () => {


### PR DESCRIPTION
## 背景

在 React 19 场景下，`CSSMotion` 的子节点如果本身已经持有 `ref`，当前实现不会再挂载内部的 motion ref。  
这会导致 `CSSMotion` 在某些场景下拿不到真实 DOM，进而无法正确监听离场动画结束事件。

这个问题在 `@rc-component/image` / `antd` 的 Image Preview 关闭流程里会被稳定触发：
关闭后节点进入 leave 状态，但不会真正卸载，最终表现为透明遮罩残留、页面无法继续点击。

## 相关问题：

fix: https://github.com/ant-design/ant-design/issues/57431

## 改动

- 在 `CSSMotion` 中合并子节点已有的 `ref` 和内部 `nodeRef`
- 不再在“子节点已有 ref”时跳过内部 ref 注入
- 新增回归测试，覆盖“子节点已有 ref 时，离场动画仍能正常结束并卸载”的场景

## 根因说明

当前逻辑在检测到 child 已有 `ref` 时，只保留 child 自己的 `ref`，导致 motion 内部拿不到 DOM 节点。  
这样一来，`transitionend` / `animationend` 无法正确绑定到目标元素，离场动画结束后也就无法进入最终清理流程。

本次修复后，child 的原始 `ref` 语义保持不变，同时 motion 也能拿到同一个 DOM 节点。

## 影响评估

- 不涉及公开 API 变更
- 不修改 motion 状态机
- 不改变 enter / leave 的时序逻辑
- 仅修复“child 已有 ref 时 motion 内部 ref 丢失”的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发布说明

* **Bug修复**
  * 改进组件对外部 ref 与子元素 ref 的合并与处理逻辑，提升过渡与渲染场景下的稳定性，避免错误引用导致的节点识别或行为异常。
  * 调整列表组件中 children 渲染函数的调用方式：仅在需要时传入第二个 ref 参数，确保单参渲染回调不意外接收 ref，从而避免引用冲突与渲染差异。

* **测试**
  * 新增严格模式下的过渡测试，验证合并后过渡结束与卸载流程正确执行，且不会触发不必要的 DOM 查找。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->