### PR TITLE
Avoid rc package deep imports

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,29 +1,6 @@
-const restrictedPackageDirectoryImports = [
-  '@rc-component/*/es',
-  '@rc-component/*/es/**',
-  '@rc-component/*/lib',
-  '@rc-component/*/lib/**',
-  'rc-*/es',
-  'rc-*/es/**',
-  'rc-*/lib',
-  'rc-*/lib/**',
-];
-
 module.exports = {
   extends: [require.resolve('@umijs/fabric/dist/eslint')],
   rules: {
-    'no-restricted-imports': [
-      'error',
-      {
-        patterns: [
-          {
-            group: restrictedPackageDirectoryImports,
-            message:
-              'Do not import package internals from es/lib. Import from the package root.',
-          },
-        ],
-      },
-    ],
     'no-template-curly-in-string': 0,
     'prefer-promise-reject-errors': 0,
     'react/no-array-index-key': 0,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,29 @@
+const restrictedPackageDirectoryImports = [
+  '@rc-component/*/es',
+  '@rc-component/*/es/**',
+  '@rc-component/*/lib',
+  '@rc-component/*/lib/**',
+  'rc-*/es',
+  'rc-*/es/**',
+  'rc-*/lib',
+  'rc-*/lib/**',
+];
+
 module.exports = {
   extends: [require.resolve('@umijs/fabric/dist/eslint')],
   rules: {
+    'no-restricted-imports': [
+      'error',
+      {
+        patterns: [
+          {
+            group: restrictedPackageDirectoryImports,
+            message:
+              'Do not import package internals from es/lib. Import from the package root.',
+          },
+        ],
+      },
+    ],
     'no-template-curly-in-string': 0,
     'prefer-promise-reject-errors': 0,
     'react/no-array-index-key': 0,

--- a/docs/examples/ssr.tsx
+++ b/docs/examples/ssr.tsx
@@ -1,6 +1,5 @@
 import { clsx } from 'clsx';
-import CSSMotion from 'rc-motion';
-import { genCSSMotion } from 'rc-motion/es/CSSMotion';
+import CSSMotion, { genCSSMotion } from 'rc-motion';
 import React from 'react';
 import { hydrate } from 'react-dom';
 import ReactDOMServer from 'react-dom/server';

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.1",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.3",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^15.0.7",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/minimatch": "5.1.2"
   },
   "dependencies": {
-    "@rc-component/util": "^1.2.0",
+    "@rc-component/util": "^1.11.0",
     "clsx": "^2.1.1"
   },
   "devDependencies": {

--- a/src/CSSMotion.tsx
+++ b/src/CSSMotion.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable react/default-props-match-prop-types, react/no-multi-comp, react/prop-types */
-import { getDOM } from '@rc-component/util/lib/Dom/findDOMNode';
 import {
   composeRef,
+  getDOM,
   getNodeRef,
   supportNodeRef,
-} from '@rc-component/util/lib/ref';
+} from '@rc-component/util';
 import { clsx } from 'clsx';
 import * as React from 'react';
 import { useRef } from 'react';

--- a/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,4 +1,4 @@
-import canUseDom from '@rc-component/util/lib/Dom/canUseDom';
+import { canUseDom } from '@rc-component/util';
 import { useEffect, useLayoutEffect } from 'react';
 
 // It's safe to use `useLayoutEffect` but the warning is annoying

--- a/src/hooks/useNextFrame.ts
+++ b/src/hooks/useNextFrame.ts
@@ -1,4 +1,4 @@
-import raf from '@rc-component/util/lib/raf';
+import { raf } from '@rc-component/util';
 import * as React from 'react';
 
 export default (): [

--- a/src/hooks/useStatus.ts
+++ b/src/hooks/useStatus.ts
@@ -1,5 +1,4 @@
-import { useEvent } from '@rc-component/util';
-import useSyncState from '@rc-component/util/lib/hooks/useSyncState';
+import { useEvent, useSyncState } from '@rc-component/util';
 import * as React from 'react';
 import { useEffect, useRef } from 'react';
 import type { CSSMotionProps } from '../CSSMotion';

--- a/src/hooks/useStepQueue.ts
+++ b/src/hooks/useStepQueue.ts
@@ -1,4 +1,4 @@
-import useState from '@rc-component/util/lib/hooks/useState';
+import { useState } from '@rc-component/util';
 import * as React from 'react';
 import type { MotionStatus, StepStatus } from '../interface';
 import {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,12 @@
-import type { CSSMotionProps } from './CSSMotion';
-import CSSMotion from './CSSMotion';
+import type { CSSMotionConfig, CSSMotionProps } from './CSSMotion';
+import CSSMotion, { genCSSMotion } from './CSSMotion';
 import type { CSSMotionListProps } from './CSSMotionList';
 import CSSMotionList from './CSSMotionList';
 import type { MotionEndEventHandler, MotionEventHandler } from './interface';
 export { default as Provider } from './context';
-export { CSSMotionList };
+export { CSSMotionList, genCSSMotion };
 export type {
+  CSSMotionConfig,
   CSSMotionProps,
   CSSMotionListProps,
   MotionEventHandler,

--- a/src/util/motion.ts
+++ b/src/util/motion.ts
@@ -1,4 +1,4 @@
-import canUseDOM from '@rc-component/util/lib/Dom/canUseDom';
+import { canUseDom } from '@rc-component/util';
 import type { MotionName } from '../CSSMotion';
 
 // ================= Transition =================
@@ -38,13 +38,13 @@ export function getVendorPrefixes(domSupport: boolean, win: object) {
 }
 
 const vendorPrefixes = getVendorPrefixes(
-  canUseDOM(),
+  canUseDom(),
   typeof window !== 'undefined' ? window : {},
 );
 
 let style = {};
 
-if (canUseDOM()) {
+if (canUseDom()) {
   ({ style } = document.createElement('div'));
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,7 @@
     "paths": {
       "@/*": ["src/*"],
       "@@/*": ["src/.umi/*"],
-      "rc-motion": ["src/index.tsx"],
-      "rc-motion/es/*": ["src/*"]
+      "rc-motion": ["src/index.tsx"]
     }
   }
 }


### PR DESCRIPTION
## 背景

antd 升级到 6.4.x 后，在 Yarn PnP、Vite、Vitest、Node 25 等环境下可能直接加载到 rc 包的 es 构建产物内部路径，导致 ESM 加载失败。这个问题暴露出 rc 包之间依赖 es/lib 构建产物内部路径的风险。

## 变更

- 增加 no-restricted-imports 规则，禁止从 rc 包的 es/lib 内部路径导入。
- 将 @rc-component/util 的深路径导入统一改为从包根入口导入。
- 升级 @rc-component/util 到 ^1.11.0，使用已公开的根入口 API。
- 从 rc-motion 根入口导出 genCSSMotion，并更新 SSR 示例避免 rc-motion/es/CSSMotion 深路径导入。
- 移除 tsconfig 中 rc-motion/es/* 路径别名，避免继续鼓励深路径使用。

## 验证

- npm run lint:tsc
- npm run lint
- npm run compile
- npm test -- --runInBand
- 已复扫仓库内 rc 包 es/lib 深路径导入，无命中。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 发行说明

* **新增功能**
  * 导出 `genCSSMotion` 函数和 `CSSMotionConfig` 类型，为用户提供更灵活的运动配置选项。

* **依赖更新**
  * 升级 `@rc-component/util` 至 `^1.11.0`
  * 升级开发依赖 `@rc-component/father-plugin` 至 `^2.2.0`

* **代码优化**
  * 简化内部模块导入路径，改进代码组织结构。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/react-component/motion/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->