### PR TITLE
Expose motion ref type

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@types/minimatch": "5.1.2"
   },
   "dependencies": {
-    "@rc-component/util": "^1.11.0",
+    "@rc-component/util": "^1.11.1",
     "clsx": "^2.1.1"
   },
   "devDependencies": {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,8 @@
-import type { CSSMotionConfig, CSSMotionProps } from './CSSMotion';
+import type {
+  CSSMotionConfig,
+  CSSMotionProps,
+  CSSMotionRef,
+} from './CSSMotion';
 import CSSMotion, { genCSSMotion } from './CSSMotion';
 import type { CSSMotionListProps } from './CSSMotionList';
 import CSSMotionList from './CSSMotionList';
@@ -8,6 +12,7 @@ export { CSSMotionList, genCSSMotion };
 export type {
   CSSMotionConfig,
   CSSMotionProps,
+  CSSMotionRef,
   CSSMotionListProps,
   MotionEventHandler,
   MotionEndEventHandler,


### PR DESCRIPTION
## 变更内容

- 升级 `@rc-component/util` 到当前 latest `^1.11.1`。
- 在根入口补充导出 `CSSMotionRef` 类型，方便下游从包根入口使用公开 API。

## 背景

配合 rc 包统一避免依赖其他 rc 包的 `es` / `lib` 构建产物内部路径，缺失的类型从包根入口补齐导出。

## 验证

- `git diff --check`
- commit hook 已执行 prettier
- 此前批量调整中已跑通 `npm run compile`、`npm run lint`、`npm test`。