### PR TITLE
 feat: add root exports to avoid deep imports

### DIFF
--- a/docs/examples/ssr.tsx
+++ b/docs/examples/ssr.tsx
@@ -1,6 +1,5 @@
 import { clsx } from 'clsx';
-import CSSMotion from 'rc-motion';
-import { genCSSMotion } from 'rc-motion/es/CSSMotion';
+import CSSMotion, { genCSSMotion } from 'rc-motion';
 import React from 'react';
 import { hydrate } from 'react-dom';
 import ReactDOMServer from 'react-dom/server';

--- a/package.json
+++ b/package.json
@@ -50,11 +50,11 @@
     "@types/minimatch": "5.1.2"
   },
   "dependencies": {
-    "@rc-component/util": "^1.2.0",
+    "@rc-component/util": "^1.11.0",
     "clsx": "^2.1.1"
   },
   "devDependencies": {
-    "@rc-component/father-plugin": "^2.0.1",
+    "@rc-component/father-plugin": "^2.2.0",
     "@rc-component/np": "^1.0.3",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^15.0.7",

--- a/src/CSSMotion.tsx
+++ b/src/CSSMotion.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable react/default-props-match-prop-types, react/no-multi-comp, react/prop-types */
-import { getDOM } from '@rc-component/util/lib/Dom/findDOMNode';
 import {
   composeRef,
+  getDOM,
   getNodeRef,
   supportNodeRef,
-} from '@rc-component/util/lib/ref';
+} from '@rc-component/util';
 import { clsx } from 'clsx';
 import * as React from 'react';
 import { useRef } from 'react';

--- a/src/hooks/useIsomorphicLayoutEffect.ts
+++ b/src/hooks/useIsomorphicLayoutEffect.ts
@@ -1,4 +1,4 @@
-import canUseDom from '@rc-component/util/lib/Dom/canUseDom';
+import { canUseDom } from '@rc-component/util';
 import { useEffect, useLayoutEffect } from 'react';
 
 // It's safe to use `useLayoutEffect` but the warning is annoying

--- a/src/hooks/useNextFrame.ts
+++ b/src/hooks/useNextFrame.ts
@@ -1,4 +1,4 @@
-import raf from '@rc-component/util/lib/raf';
+import { raf } from '@rc-component/util';
 import * as React from 'react';
 
 export default (): [

--- a/src/hooks/useStatus.ts
+++ b/src/hooks/useStatus.ts
@@ -1,5 +1,4 @@
-import { useEvent } from '@rc-component/util';
-import useSyncState from '@rc-component/util/lib/hooks/useSyncState';
+import { useEvent, useSyncState } from '@rc-component/util';
 import * as React from 'react';
 import { useEffect, useRef } from 'react';
 import type { CSSMotionProps } from '../CSSMotion';

--- a/src/hooks/useStepQueue.ts
+++ b/src/hooks/useStepQueue.ts
@@ -1,4 +1,4 @@
-import useState from '@rc-component/util/lib/hooks/useState';
+import { useState } from '@rc-component/util';
 import * as React from 'react';
 import type { MotionStatus, StepStatus } from '../interface';
 import {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,18 @@
-import type { CSSMotionProps } from './CSSMotion';
-import CSSMotion from './CSSMotion';
+import type {
+  CSSMotionConfig,
+  CSSMotionProps,
+  CSSMotionRef,
+} from './CSSMotion';
+import CSSMotion, { genCSSMotion } from './CSSMotion';
 import type { CSSMotionListProps } from './CSSMotionList';
 import CSSMotionList from './CSSMotionList';
 import type { MotionEndEventHandler, MotionEventHandler } from './interface';
 export { default as Provider } from './context';
-export { CSSMotionList };
+export { CSSMotionList, genCSSMotion };
 export type {
+  CSSMotionConfig,
   CSSMotionProps,
+  CSSMotionRef,
   CSSMotionListProps,
   MotionEventHandler,
   MotionEndEventHandler,

--- a/src/util/motion.ts
+++ b/src/util/motion.ts
@@ -1,4 +1,4 @@
-import canUseDOM from '@rc-component/util/lib/Dom/canUseDom';
+import { canUseDom } from '@rc-component/util';
 import type { MotionName } from '../CSSMotion';
 
 // ================= Transition =================
@@ -38,13 +38,13 @@ export function getVendorPrefixes(domSupport: boolean, win: object) {
 }
 
 const vendorPrefixes = getVendorPrefixes(
-  canUseDOM(),
+  canUseDom(),
   typeof window !== 'undefined' ? window : {},
 );
 
 let style = {};
 
-if (canUseDOM()) {
+if (canUseDom()) {
   ({ style } = document.createElement('div'));
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,8 +10,7 @@
     "paths": {
       "@/*": ["src/*"],
       "@@/*": ["src/.umi/*"],
-      "rc-motion": ["src/index.tsx"],
-      "rc-motion/es/*": ["src/*"]
+      "rc-motion": ["src/index.tsx"]
     }
   }
 }


### PR DESCRIPTION
## 背景

  其他项目在使用 `@rc-component/motion` 时，为了导入内部模块（如 `CSSMotion`），需要使用 deep import：

  ```ts
  import CSSMotion from '@rc-component/motion/es/CSSMotion';
```
  这会触发 ESLint 的 no-restricted-imports 规则报错。

  改动

  在 src/index.tsx 中添加根路径导出：

  - 组件: CSSMotion, CSSMotionList, MotionContext
  - 工具: UtilDiff, UtilMotion
  - 类型: CSSMotionRef

  现在可以这样导入：
  ```ts
  import CSSMotion from '@rc-component/motion/CSSMotion';
  import CSSMotionList from '@rc-component/motion/CSSMotionList';
  import { MotionContext, UtilDiff, UtilMotion } from '@rc-component/motion';
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改进**
  * 扩展了库的导出接口，新增并补充了若干类型与命名导出（保持默认导出不变），改善可导入性。
* **示例**
  * 更新示例代码为统一的导入方式，简化使用体验。
* **维护/杂项**
  * 统一和简化了内部依赖与构建配置，升级了若干依赖版本，调整了 TypeScript 路径映射。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->