### PR TITLE
feat: export CSSMotionRef type

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,8 @@
-import type { CSSMotionConfig, CSSMotionProps } from './CSSMotion';
+import type {
+  CSSMotionConfig,
+  CSSMotionProps,
+  CSSMotionRef,
+} from './CSSMotion';
 import CSSMotion, { genCSSMotion } from './CSSMotion';
 import type { CSSMotionListProps } from './CSSMotionList';
 import CSSMotionList from './CSSMotionList';
@@ -8,6 +12,7 @@ export { CSSMotionList, genCSSMotion };
 export type {
   CSSMotionConfig,
   CSSMotionProps,
+  CSSMotionRef,
   CSSMotionListProps,
   MotionEventHandler,
   MotionEndEventHandler,


### PR DESCRIPTION
rc-dailog 使用了rc-motion 的类型 CSSMotionRef 。
```tsx 
 import type { CSSMotionRef } from '@rc-component/motion/es/CSSMotion';
```
导致报错  no-restricted-imports
因此 在 src/index.tsx 中添加根路径导出类型: CSSMotionRef