### PR TITLE
refactor: migrate CSSMotionList to FC

### DIFF
--- a/src/CSSMotionList.tsx
+++ b/src/CSSMotionList.tsx
@@ -75,7 +75,7 @@ function getDerivedKeyEntities(
   const parsedKeyObjects = parseKeys(keys);
   const mixedKeyEntities = diffKeys(keyEntities, parsedKeyObjects);
 
-  return mixedKeyEntities.filter(entity => {
+  const nextKeyEntities = mixedKeyEntities.filter(entity => {
     const prevEntity = keyEntities.find(({ key }) => entity.key === key);
 
     // Remove if already mark as removed
@@ -88,6 +88,10 @@ function getDerivedKeyEntities(
     }
     return true;
   });
+
+  return isSameKeyEntities(keyEntities, nextKeyEntities)
+    ? keyEntities
+    : nextKeyEntities;
 }
 
 function shallowEqualKeyObject(origin: KeyObject, target: KeyObject) {

--- a/src/CSSMotionList.tsx
+++ b/src/CSSMotionList.tsx
@@ -2,6 +2,7 @@
 import * as React from 'react';
 import type { CSSMotionProps } from './CSSMotion';
 import OriginCSSMotion, { isRefNotConsumed } from './CSSMotion';
+import useIsomorphicLayoutEffect from './hooks/useIsomorphicLayoutEffect';
 import type { KeyObject } from './util/diff';
 import {
   diffKeys,
@@ -67,6 +68,49 @@ export interface CSSMotionListState {
   keyEntities: KeyObject[];
 }
 
+function getDerivedKeyEntities(
+  keys: CSSMotionListProps['keys'],
+  keyEntities: KeyObject[],
+) {
+  const parsedKeyObjects = parseKeys(keys);
+  const mixedKeyEntities = diffKeys(keyEntities, parsedKeyObjects);
+
+  return mixedKeyEntities.filter(entity => {
+    const prevEntity = keyEntities.find(({ key }) => entity.key === key);
+
+    // Remove if already mark as removed
+    if (
+      prevEntity &&
+      prevEntity.status === STATUS_REMOVED &&
+      entity.status === STATUS_REMOVE
+    ) {
+      return false;
+    }
+    return true;
+  });
+}
+
+function shallowEqualKeyObject(origin: KeyObject, target: KeyObject) {
+  const originRecord = origin as Record<string, any>;
+  const targetRecord = target as Record<string, any>;
+  const originKeys = Object.keys(originRecord);
+  const targetKeys = Object.keys(targetRecord);
+
+  return (
+    originKeys.length === targetKeys.length &&
+    originKeys.every(key => originRecord[key] === targetRecord[key])
+  );
+}
+
+function isSameKeyEntities(origin: KeyObject[], target: KeyObject[]) {
+  return (
+    origin.length === target.length &&
+    origin.every((entity, index) =>
+      shallowEqualKeyObject(entity, target[index]),
+    )
+  );
+}
+
 /**
  * Generate a CSSMotionList component with config
  * @param transitionSupport No need since CSSMotionList no longer depends on transition support
@@ -75,123 +119,110 @@ export interface CSSMotionListState {
 export function genCSSMotionList(
   transitionSupport: boolean,
   CSSMotion = OriginCSSMotion,
-): React.ComponentClass<CSSMotionListProps> {
-  class CSSMotionList extends React.Component<
-    CSSMotionListProps,
-    CSSMotionListState
-  > {
-    static defaultProps = {
-      component: 'div',
-    };
+): React.ComponentType<CSSMotionListProps> {
+  const CSSMotionList: React.FC<CSSMotionListProps> = props => {
+    const {
+      component = 'div',
+      children,
+      onVisibleChanged,
+      onAllRemoved,
+      ...restProps
+    } = props;
+    const { keys } = restProps;
 
-    state: CSSMotionListState = {
-      keyEntities: [],
-    };
+    const [keyEntities, setKeyEntities] = React.useState<KeyObject[]>(() =>
+      getDerivedKeyEntities(keys, []),
+    );
+    const restKeysCountRef = React.useRef<number | null>(null);
+    const onAllRemovedRef = React.useRef(onAllRemoved);
 
-    static getDerivedStateFromProps(
-      { keys }: CSSMotionListProps,
-      { keyEntities }: CSSMotionListState,
-    ) {
-      const parsedKeyObjects = parseKeys(keys);
-      const mixedKeyEntities = diffKeys(keyEntities, parsedKeyObjects);
+    onAllRemovedRef.current = onAllRemoved;
 
-      return {
-        keyEntities: mixedKeyEntities.filter(entity => {
-          const prevEntity = keyEntities.find(({ key }) => entity.key === key);
+    useIsomorphicLayoutEffect(() => {
+      setKeyEntities(prevKeyEntities => {
+        const nextKeyEntities = getDerivedKeyEntities(keys, prevKeyEntities);
 
-          // Remove if already mark as removed
-          if (
-            prevEntity &&
-            prevEntity.status === STATUS_REMOVED &&
-            entity.status === STATUS_REMOVE
-          ) {
-            return false;
-          }
-          return true;
-        }),
-      };
-    }
+        return isSameKeyEntities(prevKeyEntities, nextKeyEntities)
+          ? prevKeyEntities
+          : nextKeyEntities;
+      });
+    });
+
+    useIsomorphicLayoutEffect(() => {
+      if (restKeysCountRef.current !== null) {
+        const restKeysCount = restKeysCountRef.current;
+        restKeysCountRef.current = null;
+
+        if (restKeysCount === 0) {
+          onAllRemovedRef.current?.();
+        }
+      }
+    }, [keyEntities]);
 
     // ZombieJ: Return the count of rest keys. It's safe to refactor if need more info.
-    removeKey = (removeKey: React.Key) => {
-      this.setState(
-        prevState => {
-          const nextKeyEntities = prevState.keyEntities.map(entity => {
-            if (entity.key !== removeKey) return entity;
-            return {
-              ...entity,
-              status: STATUS_REMOVED,
-            };
-          });
-
+    const removeKey = React.useCallback((removedKey: React.Key) => {
+      setKeyEntities(prevKeyEntities => {
+        const nextKeyEntities = prevKeyEntities.map(entity => {
+          if (entity.key !== removedKey) return entity;
           return {
-            keyEntities: nextKeyEntities,
+            ...entity,
+            status: STATUS_REMOVED,
           };
-        },
-        () => {
-          const { keyEntities } = this.state;
-          const restKeysCount = keyEntities.filter(
-            ({ status }) => status !== STATUS_REMOVED,
-          ).length;
+        });
 
-          if (restKeysCount === 0 && this.props.onAllRemoved) {
-            this.props.onAllRemoved();
-          }
-        },
-      );
-    };
+        restKeysCountRef.current = nextKeyEntities.filter(
+          ({ status }) => status !== STATUS_REMOVED,
+        ).length;
 
-    render() {
-      const { keyEntities } = this.state;
-      const {
-        component,
-        children,
-        onVisibleChanged,
-        onAllRemoved,
-        ...restProps
-      } = this.props;
-
-      const Component = component || React.Fragment;
-
-      const motionProps: CSSMotionProps = {};
-      MOTION_PROP_NAMES.forEach(prop => {
-        motionProps[prop] = restProps[prop];
-        delete restProps[prop];
+        return isSameKeyEntities(prevKeyEntities, nextKeyEntities)
+          ? prevKeyEntities
+          : nextKeyEntities;
       });
-      delete restProps.keys;
+    }, []);
 
-      return (
-        <Component {...restProps}>
-          {keyEntities.map(({ status, ...eventProps }, index) => {
-            const visible = status === STATUS_ADD || status === STATUS_KEEP;
-            return (
-              <CSSMotion
-                {...motionProps}
-                key={eventProps.key}
-                visible={visible}
-                eventProps={eventProps}
-                onVisibleChanged={changedVisible => {
-                  onVisibleChanged?.(changedVisible, { key: eventProps.key });
+    const Component = component || React.Fragment;
 
-                  if (!changedVisible) {
-                    this.removeKey(eventProps.key);
-                  }
-                }}
-              >
-                {isRefNotConsumed(children)
-                  ? props =>
-                      (children as ChildrenWithoutRef)({
-                        ...props,
-                        index,
-                      })
-                  : (props, ref) => children({ ...props, index }, ref)}
-              </CSSMotion>
-            );
-          })}
-        </Component>
-      );
-    }
-  }
+    const motionProps: CSSMotionProps = {};
+    MOTION_PROP_NAMES.forEach(prop => {
+      motionProps[prop] = restProps[prop];
+      delete restProps[prop];
+    });
+    delete restProps.keys;
+
+    return (
+      <Component {...restProps}>
+        {keyEntities.map(({ status, ...eventProps }, index) => {
+          const visible = status === STATUS_ADD || status === STATUS_KEEP;
+          return (
+            <CSSMotion
+              {...motionProps}
+              key={eventProps.key}
+              visible={visible}
+              eventProps={eventProps}
+              onVisibleChanged={changedVisible => {
+                onVisibleChanged?.(changedVisible, { key: eventProps.key });
+
+                if (!changedVisible) {
+                  removeKey(eventProps.key);
+                }
+              }}
+            >
+              {isRefNotConsumed(children)
+                ? motionChildrenProps =>
+                    (children as ChildrenWithoutRef)({
+                      ...motionChildrenProps,
+                      index,
+                    })
+                : (motionChildrenProps, ref) =>
+                    children({ ...motionChildrenProps, index }, ref)}
+            </CSSMotion>
+          );
+        })}
+      </Component>
+    );
+  };
+
+  CSSMotionList.displayName = 'CSSMotionList';
 
   return CSSMotionList;
 }

--- a/src/CSSMotionList.tsx
+++ b/src/CSSMotionList.tsx
@@ -91,6 +91,10 @@ function getDerivedKeyEntities(
 }
 
 function shallowEqualKeyObject(origin: KeyObject, target: KeyObject) {
+  if (origin === target) {
+    return true;
+  }
+
   const originRecord = origin as Record<string, any>;
   const targetRecord = target as Record<string, any>;
   const originKeys = Object.keys(originRecord);
@@ -98,11 +102,19 @@ function shallowEqualKeyObject(origin: KeyObject, target: KeyObject) {
 
   return (
     originKeys.length === targetKeys.length &&
-    originKeys.every(key => originRecord[key] === targetRecord[key])
+    originKeys.every(
+      key =>
+        Object.prototype.hasOwnProperty.call(targetRecord, key) &&
+        Object.is(originRecord[key], targetRecord[key]),
+    )
   );
 }
 
 function isSameKeyEntities(origin: KeyObject[], target: KeyObject[]) {
+  if (origin === target) {
+    return true;
+  }
+
   return (
     origin.length === target.length &&
     origin.every((entity, index) =>
@@ -133,36 +145,37 @@ export function genCSSMotionList(
     const [keyEntities, setKeyEntities] = React.useState<KeyObject[]>(() =>
       getDerivedKeyEntities(keys, []),
     );
-    const restKeysCountRef = React.useRef<number | null>(null);
+    const prevKeyEntitiesRef = React.useRef<KeyObject[]>(keyEntities);
     const onAllRemovedRef = React.useRef(onAllRemoved);
 
     onAllRemovedRef.current = onAllRemoved;
 
-    useIsomorphicLayoutEffect(() => {
-      setKeyEntities(prevKeyEntities => {
-        const nextKeyEntities = getDerivedKeyEntities(keys, prevKeyEntities);
-
-        return isSameKeyEntities(prevKeyEntities, nextKeyEntities)
-          ? prevKeyEntities
-          : nextKeyEntities;
-      });
-    });
+    let mergedKeyEntities = keyEntities;
+    const nextKeyEntities = getDerivedKeyEntities(keys, keyEntities);
+    if (!isSameKeyEntities(keyEntities, nextKeyEntities)) {
+      setKeyEntities(nextKeyEntities);
+      mergedKeyEntities = nextKeyEntities;
+    }
 
     useIsomorphicLayoutEffect(() => {
-      if (restKeysCountRef.current !== null) {
-        const restKeysCount = restKeysCountRef.current;
-        restKeysCountRef.current = null;
+      const prevActiveCount = prevKeyEntitiesRef.current.filter(
+        ({ status }) => status !== STATUS_REMOVED,
+      ).length;
+      const currentActiveCount = mergedKeyEntities.filter(
+        ({ status }) => status !== STATUS_REMOVED,
+      ).length;
 
-        if (restKeysCount === 0) {
-          onAllRemovedRef.current?.();
-        }
+      if (prevActiveCount > 0 && currentActiveCount === 0) {
+        onAllRemovedRef.current?.();
       }
-    }, [keyEntities]);
+
+      prevKeyEntitiesRef.current = mergedKeyEntities;
+    }, [mergedKeyEntities]);
 
     // ZombieJ: Return the count of rest keys. It's safe to refactor if need more info.
     const removeKey = React.useCallback((removedKey: React.Key) => {
       setKeyEntities(prevKeyEntities => {
-        const nextKeyEntities = prevKeyEntities.map(entity => {
+        const nextRemovedKeyEntities = prevKeyEntities.map(entity => {
           if (entity.key !== removedKey) return entity;
           return {
             ...entity,
@@ -170,13 +183,9 @@ export function genCSSMotionList(
           };
         });
 
-        restKeysCountRef.current = nextKeyEntities.filter(
-          ({ status }) => status !== STATUS_REMOVED,
-        ).length;
-
-        return isSameKeyEntities(prevKeyEntities, nextKeyEntities)
+        return isSameKeyEntities(prevKeyEntities, nextRemovedKeyEntities)
           ? prevKeyEntities
-          : nextKeyEntities;
+          : nextRemovedKeyEntities;
       });
     }, []);
 
@@ -191,7 +200,7 @@ export function genCSSMotionList(
 
     return (
       <Component {...restProps}>
-        {keyEntities.map(({ status, ...eventProps }, index) => {
+        {mergedKeyEntities.map(({ status, ...eventProps }, index) => {
           const visible = status === STATUS_ADD || status === STATUS_KEEP;
           return (
             <CSSMotion

--- a/tests/CSSMotionList.spec.tsx
+++ b/tests/CSSMotionList.spec.tsx
@@ -174,6 +174,77 @@ describe('CSSMotionList', () => {
     );
   });
 
+  it('should support children ref when component is false', () => {
+    const CSSMotionList = genCSSMotionList(false);
+
+    const { container } = render(
+      <CSSMotionList motionName="transition" component={false} keys={['a']}>
+        {({ key }, ref) => (
+          <div ref={ref as React.Ref<HTMLDivElement>} className="motion-box">
+            {key}
+          </div>
+        )}
+      </CSSMotionList>,
+    );
+
+    expect(container.children).toHaveLength(1);
+    expect(container.querySelector('.motion-box')).toHaveTextContent('a');
+  });
+
+  it('should not require onAllRemoved', () => {
+    const CSSMotionList = genCSSMotionList(false);
+
+    const Demo = ({ keys }: { keys: string[] }) => (
+      <CSSMotionList motionName="transition" keys={keys}>
+        {({ key }) => <div className="motion-box">{key}</div>}
+      </CSSMotionList>
+    );
+
+    const { rerender } = render(<Demo keys={['a']} />);
+
+    act(() => {
+      jest.runAllTimers();
+    });
+
+    expect(() => {
+      rerender(<Demo keys={[]} />);
+      act(() => {
+        jest.runAllTimers();
+      });
+    }).not.toThrow();
+  });
+
+  it('should skip state update when removed key is already removed', () => {
+    const CSSMotion = React.forwardRef<any, any>(
+      ({ children, eventProps, onVisibleChanged }, _ref) => (
+        <button
+          className="trigger"
+          type="button"
+          onClick={() => {
+            onVisibleChanged(false);
+            onVisibleChanged(false);
+          }}
+        >
+          {children(eventProps)}
+        </button>
+      ),
+    );
+    const CSSMotionList = genCSSMotionList(false, CSSMotion);
+
+    const Demo = ({ keys }: { keys: string[] }) => (
+      <CSSMotionList motionName="transition" keys={keys}>
+        {({ key }) => <span className="motion-box">{key}</span>}
+      </CSSMotionList>
+    );
+
+    const { container, rerender } = render(<Demo keys={['a']} />);
+    rerender(<Demo keys={[]} />);
+    const trigger = container.querySelector('.trigger');
+    fireEvent.click(trigger);
+
+    expect(container.querySelector('.motion-box')).toBeFalsy();
+  });
+
   it('should update event props when key object shape changes', () => {
     const CSSMotionList = genCSSMotionList(false);
     const hasOwn = Object.prototype.hasOwnProperty;

--- a/tests/CSSMotionList.spec.tsx
+++ b/tests/CSSMotionList.spec.tsx
@@ -173,4 +173,34 @@ describe('CSSMotionList', () => {
       '1',
     );
   });
+
+  it('should update event props when key object shape changes', () => {
+    const CSSMotionList = genCSSMotionList(false);
+    const hasOwn = Object.prototype.hasOwnProperty;
+
+    const Demo = ({ keys }: { keys: CSSMotionListProps['keys'] }) => (
+      <CSSMotionList motionName="transition" keys={keys}>
+        {props => (
+          <div
+            className="motion-box"
+            data-has-foo={hasOwn.call(props, 'foo')}
+            data-has-bar={hasOwn.call(props, 'bar')}
+          />
+        )}
+      </CSSMotionList>
+    );
+
+    const { container, rerender } = render(
+      <Demo keys={[{ key: 'a', foo: undefined }]} />,
+    );
+    const getBox = () => container.querySelector<HTMLDivElement>('.motion-box');
+
+    expect(getBox()).toHaveAttribute('data-has-foo', 'true');
+    expect(getBox()).toHaveAttribute('data-has-bar', 'false');
+
+    rerender(<Demo keys={[{ key: 'a', bar: undefined }]} />);
+
+    expect(getBox()).toHaveAttribute('data-has-foo', 'false');
+    expect(getBox()).toHaveAttribute('data-has-bar', 'true');
+  });
 });


### PR DESCRIPTION
### 背景

Ant Design issue ant-design/ant-design#58404 正在清理依赖中的 React class component。`@rc-component/motion` 中的 `CSSMotionList` 仍使用 class component，本 PR 将其迁移为函数组件，不引入公开 API 变化。

### 改动内容

- 将 `CSSMotionList` 从 class component 迁移为函数组件。
- 抽出 keyEntities 派生逻辑，继续复用现有 `diffKeys` 与移除状态过滤。
- 使用 hooks 保留 key remove、`onVisibleChanged`、`onAllRemoved` 的触发行为。
- 保留 `component` 默认值、motion props 拆分以及 children ref 兼容分支。

### 验证

- `npm test`
- `npm run lint`（仅保留既有 warning）
- `npm run lint:tsc`
- `npm run compile`（仅保留既有 warning）
- `git diff --check HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **重构**
  * 将列表动画组件迁移为函数组件，基于合并后的实体集合渲染，并通过状态推导可见性。
  * 精细化移除流程，仅在活动项从“存在”变为“全移除”时触发相关回调；移除后避免重复更新错误状态。
* **兼容性**
  * 公共组件返回类型调整为更通用的组件类型，兼容更多用法场景。
* **测试**
  * 新增覆盖子渲染 ref 参数获取、无需依赖回调的移除稳定性、重复移除不触发异常，以及 keys 字段形状变更后数据属性正确切换的用例。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->